### PR TITLE
Align Veridium diving gear with Create mechanics

### DIFF
--- a/src/main/java/com/tek_sama/create_veridium_expansion/content/armor/VeridiumDivingBootsItem.java
+++ b/src/main/java/com/tek_sama/create_veridium_expansion/content/armor/VeridiumDivingBootsItem.java
@@ -1,11 +1,13 @@
 package com.tek_sama.create_veridium_expansion.content.armor;
 
+import net.minecraft.world.entity.Pose;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ArmorItem;
 import net.minecraft.world.item.ArmorMaterial;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.Vec3;
 
 public class VeridiumDivingBootsItem extends ArmorItem {
     public VeridiumDivingBootsItem(ArmorMaterial material, Type type, Item.Properties props) {
@@ -16,13 +18,31 @@ public class VeridiumDivingBootsItem extends ArmorItem {
     public void onArmorTick(ItemStack stack, Level level, Player player) {
         if (level.isClientSide) return;
 
-        if ((player.isInWaterOrBubble() || player.isInLava()) && !player.onGround() && !player.isSpectator()) {
-            var v = player.getDeltaMovement();
-            double down = player.isInLava() ? -0.12 : -0.10;
-            if (v.y > -0.9) {
-                player.setDeltaMovement(v.x, v.y + down, v.z);
-                player.hurtMarked = true; // force MAJ côté client
-            }
+        if (!affects(player))
+            return;
+
+        Vec3 motion = player.getDeltaMovement();
+        player.setOnGround(player.onGround() || player.verticalCollision);
+        if (player.onGround()) {
+            motion = motion.add(0, .5f, 0);
+            player.setOnGround(false);
+        } else {
+            motion = motion.add(0, -0.05f, 0);
         }
+
+        float multiplier = 1.3f;
+        if (motion.multiply(1, 0, 1).length() < 0.145f && (player.zza > 0 || player.xxa != 0) && !player.isShiftKeyDown())
+            motion = motion.multiply(multiplier, 1, multiplier);
+        player.setDeltaMovement(motion);
+    }
+
+    private static boolean affects(Player player) {
+        if (!player.isInWater())
+            return false;
+        if (player.getPose() == Pose.SWIMMING)
+            return false;
+        if (player.getAbilities().flying)
+            return false;
+        return true;
     }
 }

--- a/src/main/java/com/tek_sama/create_veridium_expansion/content/armor/VeridiumDivingHelmetItem.java
+++ b/src/main/java/com/tek_sama/create_veridium_expansion/content/armor/VeridiumDivingHelmetItem.java
@@ -1,8 +1,11 @@
 package com.tek_sama.create_veridium_expansion.content.armor;
 
+import com.tek_sama.create_veridium_expansion.content.backtank.VeridiumBacktankItem;
+import com.tek_sama.create_veridium_expansion.content.backtank.VeridiumBacktankUtil;
 import net.minecraft.world.effect.MobEffect;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.effect.MobEffects;
+import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ArmorItem;
 import net.minecraft.world.item.ArmorMaterial;
@@ -19,9 +22,25 @@ public class VeridiumDivingHelmetItem extends ArmorItem {
     public void onArmorTick(ItemStack stack, Level level, Player player) {
         if (level.isClientSide) return;
 
-        if (player.isInWaterOrBubble() || player.isInLava()) {
-            tickEffect(player, MobEffects.NIGHT_VISION, 220, 0);
-        }
+        boolean inFluid = player.isInWaterOrBubble() || player.isInLava();
+        if (!inFluid)
+            return;
+
+        ItemStack chest = player.getItemBySlot(EquipmentSlot.CHEST);
+        if (!(chest.getItem() instanceof VeridiumBacktankItem))
+            return;
+
+        if (VeridiumBacktankUtil.getAir(chest) <= 0)
+            return;
+
+        if (level.getGameTime() % 20 == 0)
+            if (!VeridiumBacktankUtil.tryConsumeAir(chest, 1))
+                return;
+
+        if (player.getAirSupply() < player.getMaxAirSupply())
+            player.setAirSupply(player.getMaxAirSupply());
+
+        tickEffect(player, MobEffects.NIGHT_VISION, 220, 0);
     }
 
     private static void tickEffect(Player player, MobEffect effect, int duration, int amplifier) {

--- a/src/main/java/com/tek_sama/create_veridium_expansion/content/backtank/VeridiumBacktankItem.java
+++ b/src/main/java/com/tek_sama/create_veridium_expansion/content/backtank/VeridiumBacktankItem.java
@@ -10,7 +10,12 @@ import net.minecraft.world.InteractionResultHolder;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.item.*;
+import net.minecraft.world.item.ArmorItem;
+import net.minecraft.world.item.ArmorMaterial;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.TooltipFlag;
+import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.Level;
 
 import java.util.List;
@@ -19,13 +24,14 @@ public class VeridiumBacktankItem extends ArmorItem {
     // tweak these to taste
     public static final int MAX_AIR = 6000; // ticks of air (~5min)
     public static final int TRANSFER_PER_TICK = 4;
+    public static final int BAR_COLOR = 0xEFEFEF;
 
     public VeridiumBacktankItem(ArmorMaterial material, Properties props) {
         super(material, Type.CHESTPLATE, props);
     }
 
     @Override
-    public void appendHoverText(ItemStack stack, TooltipContext ctx, List<Component> tooltip, TooltipFlag flag) {
+    public void appendHoverText(ItemStack stack, Item.TooltipContext ctx, List<Component> tooltip, TooltipFlag flag) {
         int air = VeridiumBacktankUtil.getAir(stack);
         tooltip.add(Component.translatable("tooltip.create_veridium_expansion.backtank.air",
                 air, MAX_AIR).withStyle(ChatFormatting.AQUA));
@@ -75,5 +81,21 @@ public class VeridiumBacktankItem extends ArmorItem {
             return InteractionResultHolder.sidedSuccess(stack, level.isClientSide);
         }
         return super.use(level, player, hand);
+    }
+
+    @Override
+    public boolean isBarVisible(ItemStack stack) {
+        return true;
+    }
+
+    @Override
+    public int getBarWidth(ItemStack stack) {
+        float remaining = VeridiumBacktankUtil.getAir(stack) / (float) MAX_AIR;
+        return Math.round(13.0F * remaining);
+    }
+
+    @Override
+    public int getBarColor(ItemStack stack) {
+        return BAR_COLOR;
     }
 }


### PR DESCRIPTION
## Summary
- show backtank air as item durability bar
- consume backtank air for diving helmet effects and breath refills
- simulate Create's heavy-boot underwater movement

## Testing
- `gradle test` *(fails: class ClientSetup is public, should be declared in a file named ClientSetup.java)*

------
https://chatgpt.com/codex/tasks/task_e_68bc235e7b488320a0a876202f148285