### PR TITLE
Use Veridium textures for backtank models

### DIFF
--- a/src/main/resources/assets/create_veridium_expansion/models/armor/veridium_backtank.json
+++ b/src/main/resources/assets/create_veridium_expansion/models/armor/veridium_backtank.json
@@ -1,8 +1,8 @@
 {
 	"credit": "Made with Blockbench",
 	"textures": {
-		"0": "create:block/netherite_backtank",
-		"particle": "create:block/netherite_backtank"
+		"0": "create_veridium_expansion:block/veridium_backtank",
+		"particle": "create_veridium_expansion:block/veridium_backtank"
 	},
 	"elements": [
 		{

--- a/src/main/resources/assets/create_veridium_expansion/models/armor/veridium_backtank_cogs.json
+++ b/src/main/resources/assets/create_veridium_expansion/models/armor/veridium_backtank_cogs.json
@@ -1,8 +1,8 @@
 {
 	"credit": "Made with Blockbench",
 	"textures": {
-		"0": "create:block/netherite_backtank",
-		"particle": "create:block/netherite_backtank"
+		"0": "create_veridium_expansion:block/veridium_backtank",
+		"particle": "create_veridium_expansion:block/veridium_backtank"
 	},
 	"elements": [
 		{

--- a/src/main/resources/assets/create_veridium_expansion/models/armor/veridium_backtank_shaft_input.json
+++ b/src/main/resources/assets/create_veridium_expansion/models/armor/veridium_backtank_shaft_input.json
@@ -1,8 +1,8 @@
 {
 	"credit": "Made with Blockbench",
 	"textures": {
-		"0": "create_veridium_expansion:block/veridium_backtank.png",
-		"particle": "create:block/netherite_backtank"
+		"0": "create_veridium_expansion:block/veridium_backtank",
+		"particle": "create_veridium_expansion:block/veridium_backtank"
 	},
 	"elements": [
 		{
@@ -29,9 +29,10 @@
 		}
 	],
 	"groups": [
-		{
-			"name": "Axle",
-			"origin": [8, 8, 8],
-			"children": []
-		}, 0, 1]
+                {
+                        "name": "Axle",
+                        "origin": [8, 8, 8],
+                        "children": []
+                }
+        ]
 }

--- a/src/main/resources/assets/create_veridium_expansion/models/item/veridium_backtank.json
+++ b/src/main/resources/assets/create_veridium_expansion/models/item/veridium_backtank.json
@@ -2,8 +2,8 @@
 	"credit": "Made with Blockbench",
 	"parent": "block/block",
 	"textures": {
-		"0": "create:block/netherite_backtank",
-		"particle": "create:block/netherite_backtank"
+		"0": "create_veridium_expansion:block/veridium_backtank",
+		"particle": "create_veridium_expansion:block/veridium_backtank"
 	},
 	"elements": [
 		{

--- a/src/main/resources/assets/create_veridium_expansion/models/item/veridium_diving_boots.json
+++ b/src/main/resources/assets/create_veridium_expansion/models/item/veridium_diving_boots.json
@@ -1,0 +1,4 @@
+{
+  "parent": "item/generated",
+  "textures": { "layer0": "create_veridium_expansion:item/veridium_diving_boots" }
+}

--- a/src/main/resources/assets/create_veridium_expansion/models/item/veridium_diving_helmet.json
+++ b/src/main/resources/assets/create_veridium_expansion/models/item/veridium_diving_helmet.json
@@ -1,0 +1,4 @@
+{
+  "parent": "item/generated",
+  "textures": { "layer0": "create_veridium_expansion:item/veridium_diving_helmet" }
+}


### PR DESCRIPTION
## Summary
- Point all backtank model JSONs at the mod's `veridium_backtank` texture
- Add item models for `veridium_diving_helmet` and `veridium_diving_boots`

## Testing
- `gradle build` *(fails: class ClientSetup is public, should be declared in a file named ClientSetup.java)*

------
https://chatgpt.com/codex/tasks/task_e_68bc2d685b448320ab6d6823033f7364