### PR TITLE
Fix client setup for Veridium backtank rendering

### DIFF
--- a/src/main/java/com/tek_sama/create_veridium_expansion/client/ClientModEvents.java
+++ b/src/main/java/com/tek_sama/create_veridium_expansion/client/ClientModEvents.java
@@ -1,10 +1,21 @@
-// in your client setup (e.g., ClientModEvents)
+package com.tek_sama.create_veridium_expansion.client;
+
+import com.tek_sama.create_veridium_expansion.CreateVeridiumExpansion;
+import com.tek_sama.create_veridium_expansion.content.backtank.VeridiumBacktankArmorLayer;
+import net.minecraft.client.renderer.entity.player.PlayerRenderer;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.client.event.EntityRenderersEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
 @Mod.EventBusSubscriber(modid = CreateVeridiumExpansion.MOD_ID, bus = Mod.EventBusSubscriber.Bus.MOD, value = Dist.CLIENT)
-public class ClientSetup {
+public class ClientModEvents {
+    private ClientModEvents() {}
+
     @SubscribeEvent
     public static void addLayers(EntityRenderersEvent.AddLayers event) {
         for (String skin : event.getSkins()) {
-            var renderer = event.getSkin(skin);
+            PlayerRenderer renderer = event.getSkin(skin);
             if (renderer != null) {
                 renderer.addLayer(new VeridiumBacktankArmorLayer(renderer));
             }

--- a/src/main/java/com/tek_sama/create_veridium_expansion/content/backtank/VeridiumBacktankBlock.java
+++ b/src/main/java/com/tek_sama/create_veridium_expansion/content/backtank/VeridiumBacktankBlock.java
@@ -4,15 +4,23 @@ package com.tek_sama.create_veridium_expansion.content.backtank;
 import com.tek_sama.create_veridium_expansion.registry.CVEBlockEntities;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.RenderShape;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
+import org.jetbrains.annotations.Nullable;
 
-public class VeridiumBacktankBlock extends Block {
-    public VeridiumBacktankBlock(Properties p) { super(p); }
+public class VeridiumBacktankBlock extends Block implements EntityBlock {
+    public VeridiumBacktankBlock(Properties p) {
+        super(p);
+    }
 
-    @Override public RenderShape getRenderShape(BlockState s) { return RenderShape.MODEL; }
+    @Override
+    public RenderShape getRenderShape(BlockState state) {
+        return RenderShape.MODEL;
+    }
 
+    @Nullable
     @Override
     public BlockEntity newBlockEntity(BlockPos pos, BlockState state) {
         return CVEBlockEntities.VERIDIUM_BACKTANK.get().create(pos, state);

--- a/src/main/java/com/tek_sama/create_veridium_expansion/content/backtank/VeridiumBacktankItem.java
+++ b/src/main/java/com/tek_sama/create_veridium_expansion/content/backtank/VeridiumBacktankItem.java
@@ -31,7 +31,7 @@ public class VeridiumBacktankItem extends ArmorItem {
     }
 
     @Override
-    public void appendHoverText(ItemStack stack, Item.TooltipContext ctx, List<Component> tooltip, TooltipFlag flag) {
+    public void appendHoverText(ItemStack stack, Level level, List<Component> tooltip, TooltipFlag flag) {
         int air = VeridiumBacktankUtil.getAir(stack);
         tooltip.add(Component.translatable("tooltip.create_veridium_expansion.backtank.air",
                 air, MAX_AIR).withStyle(ChatFormatting.AQUA));


### PR DESCRIPTION
## Summary
- Register `VeridiumBacktankArmorLayer` on player renderers in a new `ClientModEvents` subscriber
- Correct backtank item tooltip signature for 1.20.1 mappings
- Implement `EntityBlock` for the backtank block so its block entity is created

## Testing
- `gradle build`

------
https://chatgpt.com/codex/tasks/task_e_68bc2f0eb19c832098145f9aa2a5c3d2