### PR TITLE
Fix Registrate dependency resolution in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ dependencies {
     runtimeOnly fg.deobf("com.simibubi.create:create-${minecraft_version}:${create_version}")
 
     // Registrate
-    implementation fg.deobf("com.tterrag.registrate:Registrate:${registrate_version}")
+    implementation "com.tterrag.registrate:Registrate:${registrate_version}"
 }
 
 tasks.named('processResources', ProcessResources).configure {


### PR DESCRIPTION
## Summary
- reference Registrate dependency without fg.deobf to avoid mapping suffix

## Testing
- `gradle build` *(fails: Could not resolve net.minecraft:client:1.20.1 due to HTTP 403 from remote repositories)*

------
https://chatgpt.com/codex/tasks/task_e_68bc829946348320ae1aaca4e4796e76